### PR TITLE
fix: update stale links, fix code bugs, and rebrand Hyle to Hyli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is a collection of examples of contracts and programs that can b
 
 Hylé does not have a native execution environment. Smart contracts do not execute code on Hylé; they describe a verification logic for a particular program.
 
-See the [documentation](https://docs.hyle.eu/developers/quickstart/) to learn more.
+See the [documentation](https://docs.hyli.org/developers/quickstart/) to learn more.
 
 > ⚠️ The examples have not been audited and are not intended for production use.
 > The authors are not responsible for any damages caused by the use of the code provided here.

--- a/check-secret-noir/README.md
+++ b/check-secret-noir/README.md
@@ -13,7 +13,7 @@ This is a demonstration project that shows how to implement a secret checking sy
 - Zero-knowledge proof based secret verification
 - Web interface for submitting identity and password
 - Real-time proof verification display
-- Secure password handling through zero-knowledge proofs, settling on Hyle network.
+- Secure password handling through zero-knowledge proofs, settling on Hyli network.
 
 ## Setup and Running
 

--- a/check-secret-noir/contract/src/main.nr
+++ b/check-secret-noir/contract/src/main.nr
@@ -1,4 +1,4 @@
-// Simple Token Contract implementation in Noir
+// Check Secret Contract implementation in Noir
 
 fn main(
     // The version of the HyleOutput. This is unchecked for now.
@@ -33,7 +33,7 @@ fn main(
     // Number of blobs in the transaction. tx_blob_count >= blob_number
     tx_blob_count: pub u32,
     // -------------------
-    // Weither the execution was successful or not. If false, the BlobTransaction will be
+    // Whether the execution was successful or not. If false, the BlobTransaction will be
     // settled as failed.
     success: pub bool,
     // ------ Private inputs ------

--- a/simple-identity-sp1/Cargo.toml
+++ b/simple-identity-sp1/Cargo.toml
@@ -7,6 +7,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" }
-client-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-client-sdk", tag = "v0.13.0-rc.1"  }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" }
+client-sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-client-sdk", tag = "v0.13.0-rc.1"  }
 

--- a/simple-identity-sp1/README.md
+++ b/simple-identity-sp1/README.md
@@ -7,7 +7,7 @@ The logic is the very similar to the `simple_token` example (for risc0)
 
 - [Rust](https://rustup.rs/)
 - [SP1 4.0.0-rc1](https://docs.succinct.xyz/getting-started/install.html)
-- [A running hyle devnet](https://docs.hyle.eu/developers/quickstart/devnet/)
+- [A running Hyli devnet](https://docs.hyli.org/developers/quickstart/devnet/)
 
 ## Running the Project
 

--- a/simple-identity-sp1/lib/src/lib.rs
+++ b/simple-identity-sp1/lib/src/lib.rs
@@ -90,7 +90,7 @@ impl IdentityContractState {
         {
             return Err("Identity already exists".to_string());
         }
-        Ok("Successfully registered identity for account: {}".to_string())
+        Ok(format!("Successfully registered identity for account: {}", account))
     }
 
     fn verify_identity(

--- a/simple-identity/Cargo.toml
+++ b/simple-identity/Cargo.toml
@@ -4,8 +4,8 @@ members = ["host", "contract", "methods"]
 default-members = ["host", "contract"]
 
 [workspace.dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
-client-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
+client-sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/simple-identity/README.md
+++ b/simple-identity/README.md
@@ -1,6 +1,6 @@
 # Simple Identity risc0 example
 
-On Hylé, any smart contract can serve as proof of identity. This flexibility allows you to register your preferred identity source as a smart contract for account identification. Hylé also ships [a native `hydentity` contract](https://github.com/Hyle-org/hyle/tree/main/contracts/hydentity) for simplicity.
+On Hyli, any smart contract can serve as proof of identity. This flexibility allows you to register your preferred identity source as a smart contract for account identification. Hyli also ships [a native `hydentity` contract](https://github.com/hyli-org/hyli/tree/main/contracts/hydentity) for simplicity.
 
 This is a Risc0 example called simple_identity.
 
@@ -8,13 +8,13 @@ This is a Risc0 example called simple_identity.
 
 - [Install Rust](https://www.rust-lang.org/tools/install) (you'll need `rustup` and Cargo).
 - For our example, [install RISC Zero](https://dev.risczero.com/api/zkvm/install).
-- [Start a single-node devnet](https://docs.hyle.eu/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
+- [Start a single-node devnet](https://docs.hyli.org/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
 
 ## Quickstart
 
 ### Build and register the identity contract
 
-To build all methods and register the smart contract on the local node [from the source](https://github.com/Hyle-org/examples/blob/simple_erc20/simple-token/host/src/main.rs), run:
+To build all methods and register the smart contract on the local node [from the source](https://github.com/hyli-org/examples/blob/main/simple-identity/host/src/main.rs), run:
 
 ```bash
 cargo run -- register-contract

--- a/simple-identity/contract/src/lib.rs
+++ b/simple-identity/contract/src/lib.rs
@@ -90,7 +90,7 @@ impl IdentityContractState {
         {
             return Err("Identity already exists".to_string());
         }
-        Ok("Successfully registered identity for account: {}".to_string())
+        Ok(format!("Successfully registered identity for account: {}", account))
     }
 
     fn verify_identity(
@@ -125,7 +125,7 @@ impl Default for IdentityContractState {
     }
 }
 
-/// Helpers to transform the contrat's state in its on-chain state digest version.
+/// Helpers to transform the contract's state in its on-chain state digest version.
 /// In an optimal version, you would here only returns a hash of the state,
 /// while storing the full-state off-chain
 impl From<sdk::StateCommitment> for IdentityContractState {

--- a/simple-identity/methods/guest/Cargo.toml
+++ b/simple-identity/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
 contract-identity = { path = "../../contract"}
 
 risc0-zkvm = { version = "1.2.5", default-features = false, features = ['std'] }

--- a/simple-token-sp1/Cargo.toml
+++ b/simple-token-sp1/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" }
-client-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-client-sdk", tag = "v0.13.0-rc.1"  }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" }
+client-sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-client-sdk", tag = "v0.13.0-rc.1"  }
 
 

--- a/simple-token-sp1/README.md
+++ b/simple-token-sp1/README.md
@@ -7,7 +7,7 @@ The logic is very similar to the `simple_token` example (for risc0)
 
 - [Rust](https://rustup.rs/)
 - [SP1 4.1.x](https://docs.succinct.xyz/getting-started/install.html)
-- [A running hyle devnet](https://docs.hyle.eu/developers/quickstart/devnet/)
+- [A running Hyli devnet](https://docs.hyli.org/developers/quickstart/devnet/)
 
 ## Running the Project
 
@@ -20,9 +20,9 @@ cd program
 cargo prove build
 ```
 
-### Register the Program on hyle
+### Register the Program on Hyli
 
-To register the program (i.e. contract) on hyle with an initial supply of 1000 run:
+To register the program (i.e. contract) on Hyli with an initial supply of 1000 run:
 
 ```sh
 cd script
@@ -37,4 +37,4 @@ cargo run --release -- transfer faucet.simple_token bob.simple_token 100
 ```
 
 This will send the transactions to transfer 100 token from faucet to bob. The suffix `.simple_token` is for identity management.
-It is the default name of this contract when it was registered. See [hyle documentation](https://docs.hyle.eu/developers/general-doc/identity/) for further details.
+It is the default name of this contract when it was registered. See [hyle documentation](https://docs.hyli.org/developers/general-doc/identity/) for further details.

--- a/simple-token-sp1/lib/src/lib.rs
+++ b/simple-token-sp1/lib/src/lib.rs
@@ -101,7 +101,7 @@ impl SimpleToken {
 impl From<sdk::StateCommitment> for SimpleToken {
     fn from(state: sdk::StateCommitment) -> Self {
         borsh::from_slice(&state.0)
-            .map_err(|_| "Could not decode hyllar state".to_string())
+            .map_err(|_| "Could not decode SimpleToken state".to_string())
             .unwrap()
     }
 }

--- a/simple-token/Cargo.toml
+++ b/simple-token/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["host", "contract", "methods"]
 
 [workspace.dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
-client-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
+client-sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/simple-token/README.md
+++ b/simple-token/README.md
@@ -6,13 +6,13 @@ Welcome to the simple_token Risc0 example.
 
 - [Install Rust](https://www.rust-lang.org/tools/install) (you'll need `rustup` and Cargo).
 - For our example, [install RISC Zero](https://dev.risczero.com/api/zkvm/install).
-- [Start a single-node devnet](https://docs.hyle.eu/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
+- [Start a single-node devnet](https://docs.hyli.org/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
 
 ## Quickstart
 
 ### Build and register the contract
 
-To build all methods and register the smart contract on the local node [from the source](https://github.com/Hyle-org/examples/blob/simple_erc20/simple-token/host/src/main.rs), run:
+To build all methods and register the smart contract on the local node [from the source](https://github.com/hyli-org/examples/blob/main/simple-token/host/src/main.rs), run:
 
 ```bash
 cargo run -- register 1000

--- a/simple-token/contract/src/lib.rs
+++ b/simple-token/contract/src/lib.rs
@@ -101,7 +101,7 @@ impl SimpleToken {
 impl From<sdk::StateCommitment> for SimpleToken {
     fn from(state: sdk::StateCommitment) -> Self {
         borsh::from_slice(&state.0)
-            .map_err(|_| "Could not decode hyllar state".to_string())
+            .map_err(|_| "Could not decode SimpleToken state".to_string())
             .unwrap()
     }
 }

--- a/simple-token/methods/guest/Cargo.toml
+++ b/simple-token/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
 contract = { path = "../../contract", package = "contract"}
 
 risc0-zkvm = { version = "1.2.5", default-features = false, features = ['std'] }

--- a/ticket-app/Cargo.toml
+++ b/ticket-app/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["host", "contract", "methods"]
 
 [workspace.dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
-client-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", tag = "v0.13.0-rc.1" } # don't forget to update methods/guest/Cargo.toml 
+client-sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-client-sdk", tag = "v0.13.0-rc.1" }
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/ticket-app/README.md
+++ b/ticket-app/README.md
@@ -10,7 +10,7 @@ The goal of this example is to attribute a ticket to a user. To do so, we need a
 
 - [Install Rust](https://www.rust-lang.org/tools/install) (you'll need `rustup` and Cargo).
 - For our example, [install RISC Zero](https://dev.risczero.com/api/zkvm/install).
-- [Start a single-node devnet](https://docs.hyle.eu/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
+- [Start a single-node devnet](https://docs.hyli.org/developers/quickstart/devnet/). We recommend using [dev-mode](https://dev.risczero.com/api/generating-proofs/dev-mode) with `-e RISC0_DEV_MODE=1` for faster iterations during development.
 
 ## Quick Start
 

--- a/ticket-app/contract/src/lib.rs
+++ b/ticket-app/contract/src/lib.rs
@@ -34,7 +34,7 @@ impl sdk::HyleContract for TicketAppState {
         sdk::StateCommitment(borsh::to_vec(self).expect("Failed to encode TicketAppState"))
     }
 }
-/// Enum representing the actions that can be performed by the Amm contract.
+/// Enum representing the actions that can be performed by the TicketApp contract.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 pub enum TicketAppAction {
     BuyTicket {},
@@ -87,7 +87,7 @@ impl TicketAppState {
                 if amount < self.ticket_price.1 {
                     return Err(format!(
                         "Transfer amount should be at least {} but was {}",
-                        self.ticket_price.0, &recipient
+                        self.ticket_price.1, amount
                     ));
                 }
             }

--- a/ticket-app/methods/guest/Cargo.toml
+++ b/ticket-app/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sdk = { git = "https://github.com/hyle-org/hyle", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
+sdk = { git = "https://github.com/hyli-org/hyli", package = "hyle-contract-sdk", features = ["risc0"], tag = "v0.13.0-rc.1" }
 contract-ticket-app = { path = "../../contract"}
 
 risc0-zkvm = { version = "1.2.5", default-features = false, features = ['std'] }


### PR DESCRIPTION
## Summary

This PR fixes stale references from the Hyle -> Hyli rebrand, corrects actual code bugs, and fixes typos across all example contracts.

### Stale links & references (21 files)
- Updated all `docs.hyle.eu` links to `docs.hyli.org` (7 occurrences across READMEs)
- Updated all `hyle-org/hyle` git dependency URLs to `hyli-org/hyli` (8 Cargo.toml files)
- Updated `Hyle-org` GitHub org references to `hyli-org` (3 README links)
- Fixed broken `simple_erc20` branch references to `main` (2 links)
- Rebranded "Hyle"/"Hylé" to "Hyli" in all READMEs

### Code bugs fixed
- **simple-identity**: `Ok("Successfully registered identity for account: {}".to_string())` used a literal `{}` instead of `format!()` — the account name was never interpolated
- **ticket-app**: Error message for insufficient transfer amount showed `self.ticket_price.0` (token name) and `&recipient` (address) instead of the expected price (`self.ticket_price.1`) and actual `amount`
- **simple-token**: Stale error message referenced "hyllar state" instead of "SimpleToken state"

### Typos & copy-paste fixes
- `contrat` → `contract` (simple-identity)
- `Weither` → `Whether` (check-secret-noir)
- `Amm contract` → `TicketApp contract` (ticket-app comment)
- `Simple Token Contract implementation in Noir` → `Check Secret Contract implementation in Noir` (check-secret-noir)

## Test plan
- [ ] Verify all updated links resolve correctly
- [ ] Verify Cargo.toml git dependencies still resolve with the new URLs
- [ ] Verify the format string fix in simple-identity produces the expected output
- [ ] Verify the ticket-app error message now shows the correct price and amount values

